### PR TITLE
Add config option to set a separate feather cost for air-dodges

### DIFF
--- a/src/main/java/com/elenai/elenaidodge2/client/ED2ClientStorage.java
+++ b/src/main/java/com/elenai/elenaidodge2/client/ED2ClientStorage.java
@@ -9,6 +9,7 @@ public class ED2ClientStorage {
 	private static boolean airborne;
 	private static double power;
 	private static double verticality;
+	private static int airborneCost;
 	private static boolean animating = ED2ClientConfig.DISPLAY_ANIMATION.get();
 	
 	public static int getCooldown() {
@@ -40,6 +41,12 @@ public class ED2ClientStorage {
 	}
 	public static void setPower(double power) {
 		ED2ClientStorage.power = power;
+	}
+	public static int getAirborneCost() {
+		return airborneCost;
+	}
+	public static void setAirborneCost(int airborneCost) {
+		ED2ClientStorage.airborneCost = airborneCost;
 	}
 	public static boolean isAnimating() {
 		return animating;

--- a/src/main/java/com/elenai/elenaidodge2/config/ED2CommonConfig.java
+++ b/src/main/java/com/elenai/elenaidodge2/config/ED2CommonConfig.java
@@ -15,6 +15,7 @@ public class ED2CommonConfig {
 
 	
 	public static final ForgeConfigSpec.ConfigValue<Boolean> DODGE_WHILST_AIRBORNE;
+	public static final ForgeConfigSpec.ConfigValue<Integer> DODGE_COST_WHILST_AIRBORNE;
 	
 	//TODO: Add the tutorial back!
 	static {
@@ -34,8 +35,10 @@ public class ED2CommonConfig {
 		DODGE_HEIGHT = BUILDER.comment("How high the player moves when dodging")
 				.define("Dodge Height", 0.2d);
 		
-		
 		DODGE_WHILST_AIRBORNE = BUILDER.comment("Whether the player can dodge in mid-air").define("Dodge Whilst Airborne", false);
+		
+		DODGE_COST_WHILST_AIRBORNE = BUILDER.comment("How many half feathers it costs to dodge while airborne")
+				.define("Dodge Cost Air", 2);
 
 		BUILDER.pop();
 		SPEC = BUILDER.build();

--- a/src/main/java/com/elenai/elenaidodge2/event/CommonEvents.java
+++ b/src/main/java/com/elenai/elenaidodge2/event/CommonEvents.java
@@ -57,7 +57,7 @@ public class CommonEvents {
 		Level level = event.getLevel();
 		if (!level.isClientSide && (event.getEntity() instanceof ServerPlayer player)) {
 			ED2Messages.sendToPlayer(new ConfigSyncSTCPacket(ED2CommonConfig.DODGE_WHILST_AIRBORNE.get(),
-					ED2CommonConfig.COOLDOWN_TIME.get(), ED2CommonConfig.DODGE_COST.get(), ED2CommonConfig.DODGE_STRENGTH.get(), ED2CommonConfig.DODGE_HEIGHT.get()), player);
+					ED2CommonConfig.COOLDOWN_TIME.get(), ED2CommonConfig.DODGE_COST.get(), ED2CommonConfig.DODGE_STRENGTH.get(), ED2CommonConfig.DODGE_HEIGHT.get(), ED2CommonConfig.DODGE_COST_WHILST_AIRBORNE.get()), player);
 		}
 	}
 

--- a/src/main/java/com/elenai/elenaidodge2/networking/messages/ConfigSyncSTCPacket.java
+++ b/src/main/java/com/elenai/elenaidodge2/networking/messages/ConfigSyncSTCPacket.java
@@ -13,13 +13,15 @@ public class ConfigSyncSTCPacket {
 	private final int cost;
 	private final double power;
 	private final double verticality;
+	private final int airborneCost;
 	
-	public ConfigSyncSTCPacket(boolean airborne, int cooldown, int cost, double power, double verticality) {
+	public ConfigSyncSTCPacket(boolean airborne, int cooldown, int cost, double power, double verticality, int airborneCost) {
 	this.airborne = airborne;
 	this.cooldown = cooldown;
 	this.cost = cost;
 	this.power = power;
 	this.verticality = verticality;
+	this.airborneCost = airborneCost;
 	}
 
 	public ConfigSyncSTCPacket(FriendlyByteBuf buf) {
@@ -28,6 +30,7 @@ public class ConfigSyncSTCPacket {
 		this.cost = buf.readInt();
 		this.power = buf.readDouble();
 		this.verticality = buf.readDouble();
+		this.airborneCost = buf.readInt();
 	}
 
 	public void toBytes(FriendlyByteBuf buf) {
@@ -36,6 +39,7 @@ public class ConfigSyncSTCPacket {
 		buf.writeInt(cost);
 		buf.writeDouble(power);
 		buf.writeDouble(verticality);
+		buf.writeInt(airborneCost);
 	}
 
 	public boolean handle(Supplier<NetworkEvent.Context> supplier) {
@@ -46,6 +50,7 @@ public class ConfigSyncSTCPacket {
 			ED2ClientStorage.setCost(cost);
 			ED2ClientStorage.setPower(power);
 			ED2ClientStorage.setVerticality(verticality);
+			ED2ClientStorage.setAirborneCost(airborneCost);
 		});
 		return true;
 	}

--- a/src/main/java/com/elenai/elenaidodge2/util/DodgeHandler.java
+++ b/src/main/java/com/elenai/elenaidodge2/util/DodgeHandler.java
@@ -19,7 +19,7 @@ public class DodgeHandler {
 				&& !instance.player.isRidingJumpable() && !instance.player.isCrouching()
 				&& ClientEvents.currentCooldown == 0 && instance.screen == null && !instance.player.isSwimming()
 				&& (instance.player.getFoodData().getFoodLevel() > 6) && !instance.player.isBlocking()
-				&&FeathersHelper.spendFeathers(ED2ClientStorage.getCost())) {
+				&& FeathersHelper.spendFeathers(instance.player.isOnGround() ? ED2ClientStorage.getCost() : ED2ClientStorage.getAirborneCost())) {
 
 			String animationDirection = DodgeDirection.BACKWARDS.name();
 


### PR DESCRIPTION
See: https://github.com/ElenaiDev/ElenaiDodge2.0/issues/96
Adds the option to set a separate cost for dodging whilst airborne.